### PR TITLE
return `[]` when `modsIndex` is undefined

### DIFF
--- a/src/lib/utils/search.ts
+++ b/src/lib/utils/search.ts
@@ -22,6 +22,7 @@ export function searchModsIndex(searchTerm: string) {
   // escape special regex characters
   const match = searchTerm.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   // return matching mod indexes
+  if (!modsIndex) return [];
   const results = modsIndex.search(match);
 
   return (


### PR DESCRIPTION
this is to prevent the website from shitting itself when the search bar is used before the mods list is loaded. might be better to force load a version if the search box is used before one is selected, but this will work for now